### PR TITLE
Removed next.config.js from the project file structure in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ notus-nextjs
 ├── layouts
 │   ├── Admin.js
 │   └── Auth.js
-├── next.config.js
 ├── package.json
 ├── pages
 │   ├── 404.js


### PR DESCRIPTION
since Notus now uses Built-In CSS Support from Next.js, it no longer needs the next.config.js.